### PR TITLE
Add url_base support to couchpotato settings.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,6 @@ default[:couchpotato][:settings] = {
   twitter_access_token_key: nil,
   twitter_access_token_secret: nil,
   twitter_username: nil,
-  urlbase: '',
+  url_base: '',
   username: 'username'
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,5 +32,6 @@ default[:couchpotato][:settings] = {
   twitter_access_token_key: nil,
   twitter_access_token_secret: nil,
   twitter_username: nil,
+  urlbase: '',
   username: 'username'
 }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,7 +61,7 @@ template ::File.join(node[:couchpotato][:config_dir], 'settings.conf') do
     twitter_access_token_key: node[:couchpotato][:settings][:twitter_access_token_key],
     twitter_access_token_secret: node[:couchpotato][:settings][:twitter_access_token_secret],
     twitter_username: node[:couchpotato][:settings][:twitter_username],
-    urlbase: node[:couchpotato][:settings][:urlbase],
+    url_base: node[:couchpotato][:settings][:url_base],
     username: node[:couchpotato][:settings][:username]
   )
   notifies :restart, 'service[couchpotato]'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,6 +61,7 @@ template ::File.join(node[:couchpotato][:config_dir], 'settings.conf') do
     twitter_access_token_key: node[:couchpotato][:settings][:twitter_access_token_key],
     twitter_access_token_secret: node[:couchpotato][:settings][:twitter_access_token_secret],
     twitter_username: node[:couchpotato][:settings][:twitter_username],
+    urlbase: node[:couchpotato][:settings][:urlbase],
     username: node[:couchpotato][:settings][:username]
   )
   notifies :restart, 'service[couchpotato]'

--- a/templates/default/settings.conf.erb
+++ b/templates/default/settings.conf.erb
@@ -6,7 +6,7 @@ data_dir =
 permission_folder = 0755
 api_key = <%= @api_key %>
 development = 0
-url_base = <%= @urlbase %> 
+url_base = <%= @url_base %> 
 debug = 0
 launch_browser = 0
 password = <%= @password %>

--- a/templates/default/settings.conf.erb
+++ b/templates/default/settings.conf.erb
@@ -6,7 +6,7 @@ data_dir =
 permission_folder = 0755
 api_key = <%= @api_key %>
 development = 0
-url_base = 
+url_base = <%= @urlbase %> 
 debug = 0
 launch_browser = 0
 password = <%= @password %>


### PR DESCRIPTION
This adds support for setting the url_base in couchpotato's settings file.

I needed this in order to run my copy of couchpotato behind an apache reverse proxy.
